### PR TITLE
Update use of collections module to avoid deprecated idiom

### DIFF
--- a/examples/ndfd/forecast.py
+++ b/examples/ndfd/forecast.py
@@ -5,7 +5,7 @@ import datetime
 import pyxb.binding.datatypes as xsd
 from pyxb.utils.six.moves.urllib.request import urlopen
 import time
-import collections
+import collections.abc
 import sys
 
 # Get the next seven days forecast for two locations
@@ -32,7 +32,7 @@ print('%s %s' % (product.title, product.category))
 source = r.head.source
 print(", ".join(source.production_center.content()))
 data = r.data
-if isinstance(data, collections.MutableSequence):
+if isinstance(data, collections.abc.MutableSequence):
     data = data.pop(0)
 print(data)
 

--- a/pyxb/binding/basis.py
+++ b/pyxb/binding/basis.py
@@ -17,7 +17,7 @@
 inherit, and that describe the content models of those schema."""
 
 import logging
-import collections
+import collections.abc
 import xml.dom
 import pyxb
 from pyxb.utils import domutils, utility, six
@@ -1163,7 +1163,7 @@ class simpleTypeDefinition (_TypeBinding_mixin, utility._DeconflictSymbols_mixin
             raise pyxb.SimpleTypeValueError(cls, value)
         value_class = cls
         if issubclass(cls, STD_list):
-            if not isinstance(value, collections.Iterable):
+            if not isinstance(value, collections.abc.Iterable):
                 raise pyxb.SimpleTypeValueError(cls, value)
             for v in value:
                 if not cls._ItemType._IsValidValue(v):
@@ -1363,7 +1363,7 @@ class STD_list (simpleTypeDefinition, six.list_type):
             if isinstance(arg1, six.string_types):
                 args = (arg1.split(),) + args[1:]
                 arg1 = args[0]
-            if isinstance(arg1, collections.Iterable):
+            if isinstance(arg1, collections.abc.Iterable):
                 new_arg1 = [ cls._ValidatedItem(_v, kw) for _v in arg1 ]
                 args = (new_arg1,) + args[1:]
         super_fn = getattr(super(STD_list, cls), '_ConvertArguments_vx', lambda *a,**kw: args)
@@ -1646,7 +1646,7 @@ class element (utility._DeconflictSymbols_mixin, _DynamicCreate_mixin):
             return self.__defaultValue
         is_plural = kw.pop('is_plural', False)
         if is_plural:
-            if not isinstance(value, collections.Iterable):
+            if not isinstance(value, collections.abc.Iterable):
                 raise pyxb.SimplePluralValueError(self.typeDefinition(), value)
             return [ self.compatibleValue(_v) for _v in value ]
         compValue = self.typeDefinition()._CompatibleValue(value, **kw);

--- a/pyxb/binding/content.py
+++ b/pyxb/binding/content.py
@@ -796,7 +796,7 @@ class WildcardUse (_FACSymbol):
     def __str__ (self):
         return 'xs:any per %s' % (self.xsdLocation(),)
 
-import collections
+import collections.abc
 
 # Do not inherit from list; that's obscene, and could cause problems with the
 # internal assumptions made by Python.  Instead delegate everything to an
@@ -804,7 +804,7 @@ import collections
 # represents list-style data structures so we can identify both lists and
 # these things which are not lists.
 @pyxb.utils.utility.BackfillComparisons
-class _PluralBinding (collections.MutableSequence):
+class _PluralBinding (collections.abc.MutableSequence):
     """Helper for element content that supports multiple occurences.
 
     This is an adapter for Python list.  Any operation that can mutate an item

--- a/tests/drivers/test-mg-sequence.py
+++ b/tests/drivers/test-mg-sequence.py
@@ -22,7 +22,7 @@ def ToDOM (instance, tag=None):
     return instance.toDOM().documentElement
 
 import unittest
-import collections
+import collections.abc
 
 class TestMGSeq (unittest.TestCase):
     def setUp (self):
@@ -50,7 +50,7 @@ class TestMGSeq (unittest.TestCase):
         self.assertTrue(isinstance(instance.first, sequence._ElementMap['first'].elementBinding().typeDefinition()))
         self.assertTrue(isinstance(instance.second_opt, sequence._ElementMap['second_opt'].elementBinding().typeDefinition()))
         self.assertTrue(isinstance(instance.third, sequence._ElementMap['third'].elementBinding().typeDefinition()))
-        self.assertTrue(isinstance(instance.fourth_0_2, collections.MutableSequence))
+        self.assertTrue(isinstance(instance.fourth_0_2, collections.abc.MutableSequence))
         self.assertEqual(1, len(instance.fourth_0_2))
         self.assertTrue(isinstance(instance.fourth_0_2[0], sequence._ElementMap['fourth_0_2'].elementBinding().typeDefinition()))
         self.assertEqual(ToDOM(instance).toxml("utf-8"), xmld)
@@ -63,7 +63,7 @@ class TestMGSeq (unittest.TestCase):
         self.assertTrue(isinstance(instance.first, sequence._ElementMap['first'].elementBinding().typeDefinition()))
         self.assertTrue(instance.second_opt is None)
         self.assertTrue(isinstance(instance.third, sequence._ElementMap['third'].elementBinding().typeDefinition()))
-        self.assertTrue(isinstance(instance.fourth_0_2, collections.MutableSequence))
+        self.assertTrue(isinstance(instance.fourth_0_2, collections.abc.MutableSequence))
         self.assertEqual(2, len(instance.fourth_0_2))
         self.assertTrue(isinstance(instance.fourth_0_2[0], sequence._ElementMap['fourth_0_2'].elementBinding().typeDefinition()))
         self.assertEqual(ToDOM(instance).toxml("utf-8"), xmld)
@@ -73,7 +73,7 @@ class TestMGSeq (unittest.TestCase):
         xmld = xmlt.encode('utf-8')
         dom = pyxb.utils.domutils.StringToDOM(xmlt)
         instance = altwrapper.createFromDOM(dom.documentElement)
-        self.assertTrue(isinstance(instance.first, collections.MutableSequence))
+        self.assertTrue(isinstance(instance.first, collections.abc.MutableSequence))
         self.assertEqual(1, len(instance.first))
         self.assertEqual(2, len(instance.second_multi))
         self.assertTrue(isinstance(instance.third, altsequence._ElementMap['third'].elementBinding().typeDefinition()))
@@ -84,7 +84,7 @@ class TestMGSeq (unittest.TestCase):
         xmld = xmlt.encode('utf-8')
         dom = pyxb.utils.domutils.StringToDOM(xmlt)
         instance = altwrapper.createFromDOM(dom.documentElement)
-        self.assertTrue(isinstance(instance.first, collections.MutableSequence))
+        self.assertTrue(isinstance(instance.first, collections.abc.MutableSequence))
         self.assertEqual(2, len(instance.first))
         self.assertEqual(0, len(instance.second_multi))
         self.assertTrue(isinstance(instance.third, altsequence._ElementMap['third'].elementBinding().typeDefinition()))
@@ -100,7 +100,7 @@ class TestMGSeq (unittest.TestCase):
         self.assertTrue(isinstance(instance.first, sequence._ElementMap['first'].elementBinding().typeDefinition()))
         self.assertTrue(instance.second_opt is None)
         self.assertTrue(isinstance(instance.third, sequence._ElementMap['third'].elementBinding().typeDefinition()))
-        self.assertTrue(isinstance(instance.fourth_0_2, collections.MutableSequence))
+        self.assertTrue(isinstance(instance.fourth_0_2, collections.abc.MutableSequence))
         self.assertEqual(0, len(instance.fourth_0_2))
         self.assertEqual(ToDOM(instance).toxml("utf-8"), xmld)
 

--- a/tests/trac/test-trac-0069.py
+++ b/tests/trac/test-trac-0069.py
@@ -59,7 +59,7 @@ eval(rv)
 from pyxb.exceptions_ import *
 
 import unittest
-import collections
+import collections.abc
 
 # Pretend whoever created the schema was helpful and had normalized it
 metadatadoc_type = MetadataDocument.typeDefinition()

--- a/tests/trac/test-trac-0071.py
+++ b/tests/trac/test-trac-0071.py
@@ -59,7 +59,7 @@ eval(rv)
 from pyxb.exceptions_ import *
 
 import unittest
-import collections
+import collections.abc
 
 # Pretend whoever created the schema was helpful and had normalized it
 metadatadoc_type = MetadataDocument.typeDefinition()
@@ -75,7 +75,7 @@ v_bind = pyxb.BIND('foo', lang='ENG')
 class TestTrac_0071 (unittest.TestCase):
     def testFieldConstructor (self):
         field = field_type('title', pyxb.BIND('foo', lang='ENG'), _element=field_element)
-        self.assertTrue(isinstance(field.value_, collections.MutableSequence))
+        self.assertTrue(isinstance(field.value_, collections.abc.MutableSequence))
         self.assertEqual(1, len(field.value_))
         self.assertTrue(isinstance(field.value_[0], value_type))
         field.validateBinding()
@@ -89,7 +89,7 @@ class TestTrac_0071 (unittest.TestCase):
 
         field = field_type(name='title', _element=field_element)
         field.value_.append(pyxb.BIND('foo', lang='ENG'))
-        self.assertTrue(isinstance(field.value_, collections.MutableSequence))
+        self.assertTrue(isinstance(field.value_, collections.abc.MutableSequence))
         self.assertEqual(1, len(field.value_))
         self.assertTrue(isinstance(field.value_[0], value_type))
         field.validateBinding()


### PR DESCRIPTION
The use of the "collections" module to access the abstract base classes
has been deprecated in Python 3.7, and will be removed in Python 3.8.
The new idiom is to access the ABCs in "collections.abc". Update the code
throughout to use the new location.

Signed-off-by: Hugo Mills <hugo@nightglass.co.uk>